### PR TITLE
[watermarkstat] Add new warning message for the 'q_shared_multi' counters

### DIFF
--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -201,7 +201,7 @@ class Watermarkstat(object):
 
         return pg_index
 
-    def build_header(self, wm_type):
+    def build_header(self, wm_type, counter_type):
         if wm_type is None:
             print("Header info is not available!", file=sys.stderr)
             sys.exit(1)
@@ -220,8 +220,12 @@ class Watermarkstat(object):
                     min_idx = element_idx
 
         if min_idx == sys.maxsize:
-            print("Object map is empty!", file=sys.stderr)
-            sys.exit(1)
+            if counter_type != 'q_shared_multi':
+                print("Object map is empty!", file=sys.stderr)
+                sys.exit(1)
+            else:
+                print("Object map from the COUNTERS_DB is empty because the multicast queues are not configured in the CONFIG_DB!")
+                sys.exit(0)
 
         self.min_idx = min_idx
         self.header_list += ["{}{}".format(wm_type["header_prefix"], idx) for idx in range(self.min_idx, max_idx + 1)]
@@ -261,7 +265,7 @@ class Watermarkstat(object):
                     data = STATUS_NA
                 table.append((buf_pool, data))
         else:
-            self.build_header(type)
+            self.build_header(type, key)
             # Get stat for each port
             for port in natsorted(self.counter_port_name_map):
                 row_data = list()


### PR DESCRIPTION
Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add a new warning message for the 'q_shared_multi' counter and not perform the exit with error code (1) because of the new implementation [sonic-swss/pull/2432](https://github.com/sonic-net/sonic-swss/pull/2432) from now on there is a valid case if there are no multicast counters inside the `COUNTERS_DB`.

In order for multicast counters to be presented in `COUNTERS_DB` the appropriate queues should be configured inside the `CONFIG_DB` (e.g `"BUFFER_QUEUE|Ethernet14|7-8"`)

#### How I did it
Change the `watermarkstat` script

#### How to verify it
Run the [sonic-mgmt/tests/iface_namingmode/test_iface_namingmode.py](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/iface_namingmode/test_iface_namingmode.py)


#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show queue watermark multicast
Object map is empty!
```

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show queue watermark multicast
Object map from COUNTERS_DB is empty, because multicast queues are not configured in CONFIG_DB!
```
