### PR TITLE
[sonic_cli_gen] Add YANG refine support

### DIFF
--- a/tests/cli_autogen_input/yang_parser_test/assert_dictionaries.py
+++ b/tests/cli_autogen_input/yang_parser_test/assert_dictionaries.py
@@ -535,14 +535,14 @@ grouping_complex = {
                 "attrs":[
                     {
                         "name":"GR_5_LEAF_1",
-                        "description": "",
+                        "description": "GR_5_LEAF_1 refine description",
                         "is-mandatory": False,
                         "is-leaf-list": False,
                         "group": "GR_5",
                     },
                     {
                         "name":"GR_5_LEAF_LIST_1",
-                        "description": "",
+                        "description": "GR_5_LEAF_LIST_1 refine description",
                         "is-mandatory": False,
                         "is-leaf-list": True,
                         "group": "GR_5",
@@ -556,7 +556,7 @@ grouping_complex = {
                     },
                     {
                         "name":"GR_6_LEAF_2",
-                        "description": "",
+                        "description": "GR_6_LEAF_2 refine description",
                         "is-mandatory": False,
                         "is-leaf-list": False,
                         "group": "GR_6",

--- a/tests/cli_autogen_input/yang_parser_test/sonic-grouping-complex.yang
+++ b/tests/cli_autogen_input/yang_parser_test/sonic-grouping-complex.yang
@@ -15,6 +15,8 @@ module sonic-grouping-complex {
 
     grouping GR_5 {
         leaf GR_5_LEAF_1 {
+            mandatory true;
+            description "GR_5_LEAF_1 description";
             type string;
         }
 
@@ -87,8 +89,23 @@ module sonic-grouping-complex {
 
                 description "OBJECT_2 description";
 
-                uses GR_5;
-                uses GR_6;
+                uses GR_5 {
+                    refine GR_5_LEAF_1 {
+                        mandatory false;
+                        description "GR_5_LEAF_1 refine description";
+                    }
+
+                    refine GR_5_LEAF_LIST_1 {
+                        description "GR_5_LEAF_LIST_1 refine description";
+                    }
+                }
+
+                uses GR_6 {
+                    refine GR_6_LEAF_2 {
+                        description "GR_6_LEAF_2 refine description";
+                    }
+                }
+
                 uses sgroup2:GR_4;
             }
         }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add [YANG "refine"](https://www.rfc-editor.org/rfc/rfc7950.html#section-7.13.2) support for the `sonic_cli_gen` utility.
YANG refine is used to override the `description` and `mandatory` statements for YANG `grouping`.

#### How I did it
Modify the `sonic_cli_gen/yang_parser.py`

#### How to verify it
Modify the `sonic_cli_gen` UT

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

