### PR TITLE
internal [SPM] Add logic to disable the feature before stopping it and enabling it before starting

### DIFF
--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -1017,8 +1017,10 @@ class PackageManager:
 
     def _stop_feature(self, package: Package):
         self._systemctl_action(package, 'stop')
+        self._systemctl_action(package, 'disable')
 
     def _start_feature(self, package: Package):
+        self._systemctl_action(package, 'enable')
         self._systemctl_action(package, 'start')
 
     def _systemctl_action(self, package: Package, action: str):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add logic to disable the feature before stopping and enabling it before starting in order to properly clean the `systemd` symlinks to avoid issues with `delayed` attribute explained in the `How to verify it` section.

#### How I did it
Add the `systemctl disable ...` after the `systemctl stop...` and the `systemctl enable ...` before the `systemctl start ..` for some feature.

#### How to verify it
- Add repository for some `featureX`
- `sonic-package-manager repository <featureX> <URL>`
- Install `featureX` version 1.0.0 where the `delayed` flag is equal to `false` (`delayed` flag means - the feature will be started right after the system boots or after the `PortInitDone` event)
- `sonic-package-manager install featureX==1.0.0 -y`
- Enable the feature in SONiC
- `config feature state featureX enabled`
- Install `featureX` version 1.0.1 where the `delayed` flag is equal to `true`
- `sonic-package-manager install featureX==1.0.1 -y`
- Check the `manifest` file to verify the `delayed` field value
- `sonic-package-manager show package manifest featureX`
- `config save -y`
- `reboot`
- Check that the `featureX` is delayed on the system start

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

